### PR TITLE
addition of error message and populates clist with errors

### DIFF
--- a/ftplugin/java/javafmt.vim
+++ b/ftplugin/java/javafmt.vim
@@ -11,22 +11,32 @@ if !exists("g:javafmt_options")
 endif
 
 function! s:javafmt(...) abort
-  if len(a:000) == 0
-    let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' - ', getline(1, '$'))
-  else
-    let files = []
-    for arg in a:000
-      let files += split(expand(arg), "\n")
-    endfor
-    let files = map(files, 'shellescape(expand(v:val))')
-    let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . join(files, ' '))
-  endif
-  if v:shell_error == 0
-    let pos = getcurpos()
-    silent! %d _
-    call setline(1, split(lines, "\n"))
-    call setpos('.', pos)
-  endif
+    if empty(globpath(&rtp, 'lib/google-java-format*.jar'))
+      echohl ErrorMsg
+      redraw
+      echomsg "Please download google-java-format and place in .vim/lib"
+      echohl None
+      return
+    endif
+    if len(a:000) == 0
+      let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . expand('%'))
+    else
+      let files = []
+      for arg in a:000
+        let files += split(expand(arg), "\n")
+      endfor
+      let files = map(files, 'shellescape(expand(v:val))')
+      let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . join(files, ' '))
+    endif
+    if v:shell_error == 0
+      let pos = getcurpos()
+      silent! %d _
+      call setline(1, split(lines, "\n"))
+      call setpos('.', pos)
+    else
+      cexp lines
+      copen
+    endif
 endfunction
 
 command! -nargs=* -complete=file JavaFmt call <SID>javafmt(<f-args>)

--- a/ftplugin/java/javafmt.vim
+++ b/ftplugin/java/javafmt.vim
@@ -1,42 +1,42 @@
 if !executable('java')
-  finish
+	finish
 endif
 
 if !exists("g:javafmt_program")
-  let g:javafmt_program = 'java -jar ' . globpath(&rtp, 'lib/google-java-format*.jar')
+	let g:javafmt_program = 'java -jar ' . globpath(&rtp, 'lib/google-java-format*.jar')
 endif
 
 if !exists("g:javafmt_options")
-  let g:javafmt_options = ''
+	let g:javafmt_options = ''
 endif
 
 function! s:javafmt(...) abort
-    if empty(globpath(&rtp, 'lib/google-java-format*.jar'))
-      echohl ErrorMsg
-      redraw
-      echomsg "Please download google-java-format and place in .vim/lib"
-      echohl None
-      return
-    endif
-    if len(a:000) == 0
-      let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . expand('%'))
-    else
-      let files = []
-      for arg in a:000
-        let files += split(expand(arg), "\n")
-      endfor
-      let files = map(files, 'shellescape(expand(v:val))')
-      let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . join(files, ' '))
-    endif
-    if v:shell_error == 0
-      let pos = getcurpos()
-      silent! %d _
-      call setline(1, split(lines, "\n"))
-      call setpos('.', pos)
-    else
-      cexp lines
-      copen
-    endif
+	if empty(globpath(&rtp, 'lib/google-java-format*.jar'))
+		echohl ErrorMsg
+		redraw
+		echomsg "Please download google-java-format and place in .vim/lib"
+		echohl None
+		return
+	endif
+	if len(a:000) == 0
+		let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . expand('%'))
+	else
+		let files = []
+		for arg in a:000
+			let files += split(expand(arg), "\n")
+		endfor
+		let files = map(files, 'shellescape(expand(v:val))')
+		let lines = system(g:javafmt_program . ' ' . g:javafmt_options . ' ' . join(files, ' '))
+	endif
+	if v:shell_error == 0
+		let pos = getcurpos()
+		silent! %d _
+		call setline(1, split(lines, "\n"))
+		call setpos('.', pos)
+	else
+		cexp lines
+		copen
+	endif
 endfunction
 
 command! -nargs=* -complete=file JavaFmt call <SID>javafmt(<f-args>)


### PR DESCRIPTION
### Error message
- In case google-java-format is not found in `rtp`
### Populates `clist`
- Useful to navigate to errors quickly
